### PR TITLE
updated deps and fixed jshint errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ release.txt
 fixtures/bower.json
 fixtures/package.json
 .log
+npm-debug.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ var _s = require('underscore.string');
 var shell = require('shelljs');
 var process = require('child_process');
 var Q = require('q');
-var helpers = require('yeoman-generator').test;
+var helpers = require('yeoman-test');
 var fs = require('fs-extra');
 var path = require('path');
 
@@ -119,16 +119,6 @@ module.exports = function (grunt) {
     shell.mkdir(grunt.config('config').demo);
     shell.cd(grunt.config('config').demo);
 
-    Q()
-      .then(generateDemo)
-      .then(function() {
-        shell.cd('../');
-      })
-      .catch(function(msg){
-        grunt.fail.warn(msg || 'failed to generate demo')
-      })
-      .finally(done);
-
     function generateDemo() {
       var deferred = Q.defer();
       var options = {
@@ -160,23 +150,22 @@ module.exports = function (grunt) {
 
       return deferred.promise;
     }
+
+    new Q()
+      .then(generateDemo)
+      .then(function() {
+        shell.cd('../');
+      })
+      .catch(function(msg){
+        grunt.fail.warn(msg || 'failed to generate demo');
+      })
+      .finally(done);
   });
 
   grunt.registerTask('releaseDemoBuild', 'builds and releases demo', function () {
     var done = this.async();
 
     shell.cd(grunt.config('config').demo);
-
-    Q()
-      .then(gruntBuild)
-      .then(gruntRelease)
-      .then(function() {
-        shell.cd('../');
-      })
-      .catch(function(msg){
-        grunt.fail.warn(msg || 'failed to release demo')
-      })
-      .finally(done);
 
     function run(cmd) {
       var deferred = Q.defer();
@@ -198,6 +187,17 @@ module.exports = function (grunt) {
     function gruntRelease() {
       return run('grunt buildcontrol:heroku');
     }
+
+    new Q()
+      .then(gruntBuild)
+      .then(gruntRelease)
+      .then(function() {
+        shell.cd('../');
+      })
+      .catch(function(msg){
+        grunt.fail.warn(msg || 'failed to release demo');
+      })
+      .finally(done);
   });
 
   grunt.registerTask('updateFixtures', 'updates package and bower fixtures', function() {
@@ -232,7 +232,7 @@ module.exports = function (grunt) {
       process.exec('bower install', {cwd: '../fixtures'}, function (error, stdout, stderr) {
         shell.cd('../../');
         done();
-      })
+      });
     });
   });
 

--- a/app/index.js
+++ b/app/index.js
@@ -16,7 +16,7 @@ var fs        = require('fs')
 /**
  * Our generator will extend Yeoman's base generator
  */
-var AngularMaterialFullstackGenerator = yeoman.generators.Base.extend({
+var AngularMaterialFullstackGenerator = yeoman.Base.extend({
 
   /**
    * Initialize variables and global settings

--- a/controller/index.js
+++ b/controller/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var yeoman = require('yeoman-generator');
 
-var Generator = yeoman.generators.Base.extend({
+var Generator = yeoman.Base.extend({
   compose: function() {
     this.composeWith('ng-component:controller', {arguments: this.arguments}, { local: require.resolve('generator-ng-component/controller') });
   }

--- a/decorator/index.js
+++ b/decorator/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var yeoman = require('yeoman-generator');
 
-var Generator = yeoman.generators.Base.extend({
+var Generator = yeoman.Base.extend({
   compose: function() {
     this.composeWith('ng-component:decorator', {arguments: this.arguments}, { local: require.resolve('generator-ng-component/decorator') });
   }

--- a/directive/index.js
+++ b/directive/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var yeoman = require('yeoman-generator');
 
-var Generator = yeoman.generators.Base.extend({
+var Generator = yeoman.Base.extend({
   compose: function() {
     this.composeWith('ng-component:directive', {arguments: this.arguments}, { local: require.resolve('generator-ng-component/directive') });
   }

--- a/factory/index.js
+++ b/factory/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var yeoman = require('yeoman-generator');
 
-var Generator = yeoman.generators.Base.extend({
+var Generator = yeoman.Base.extend({
   compose: function() {
     this.composeWith('ng-component:factory', {arguments: this.arguments}, { local: require.resolve('generator-ng-component/factory') });
   }

--- a/filter/index.js
+++ b/filter/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var yeoman = require('yeoman-generator');
 
-var Generator = yeoman.generators.Base.extend({
+var Generator = yeoman.Base.extend({
   compose: function() {
     this.composeWith('ng-component:filter', {arguments: this.arguments}, { local: require.resolve('generator-ng-component/filter') });
   }

--- a/generators/constant/index.js
+++ b/generators/constant/index.js
@@ -4,10 +4,10 @@ var yeoman = require('yeoman-generator');
 var util = require('util');
 
 var Generator = module.exports = function Generator() {
-  yeoman.generators.Base.apply(this, arguments);
+  yeoman.Base.apply(this, arguments);
 };
 
-util.inherits(Generator, yeoman.generators.Base);
+util.inherits(Generator, yeoman.Base);
 
 Generator.prototype.deprecated = function deprecated() {
   this.log(chalk.yellow('This sub-generator is deprecated. \n'));

--- a/generators/deploy/index.js
+++ b/generators/deploy/index.js
@@ -4,7 +4,7 @@ var yeoman = require('yeoman-generator');
 var util = require('util');
 
 var Generator = module.exports = function Generator() {
-  yeoman.generators.Base.apply(this, arguments);
+  yeoman.Base.apply(this, arguments);
 };
 
 util.inherits(Generator, yeoman.generators.NamedBase);

--- a/generators/value/index.js
+++ b/generators/value/index.js
@@ -4,10 +4,10 @@ var yeoman = require('yeoman-generator');
 var util = require('util');
 
 var Generator = module.exports = function Generator() {
-  yeoman.generators.Base.apply(this, arguments);
+  yeoman.Base.apply(this, arguments);
 };
 
-util.inherits(Generator, yeoman.generators.Base);
+util.inherits(Generator, yeoman.Base);
 
 Generator.prototype.deprecated = function deprecated() {
   this.log(chalk.yellow('This sub-generator is deprecated. \n'));

--- a/generators/view/index.js
+++ b/generators/view/index.js
@@ -4,10 +4,10 @@ var yeoman = require('yeoman-generator');
 var util = require('util');
 
 var Generator = module.exports = function Generator() {
-  yeoman.generators.Base.apply(this, arguments);
+  yeoman.Base.apply(this, arguments);
 };
 
-util.inherits(Generator, yeoman.generators.Base);
+util.inherits(Generator, yeoman.Base);
 
 Generator.prototype.deprecated = function deprecated() {
   this.log(chalk.yellow('This sub-generator is deprecated. \n'));

--- a/heroku/index.js
+++ b/heroku/index.js
@@ -6,7 +6,7 @@ var chalk = require('chalk');
 var path = require('path');
 
 var Generator = module.exports = function Generator() {
-  yeoman.generators.Base.apply(this, arguments);
+  yeoman.Base.apply(this, arguments);
   this.sourceRoot(path.join(__dirname, './templates'));
 
   try {

--- a/openshift/index.js
+++ b/openshift/index.js
@@ -8,7 +8,7 @@ var exec = childProcess.exec;
 var spawn = childProcess.spawn;
 
 var Generator = module.exports = function Generator() {
-  yeoman.generators.Base.apply(this, arguments);
+  yeoman.Base.apply(this, arguments);
   this.sourceRoot(path.join(__dirname, './templates'));
 
   try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-angular-material-fullstack",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Yeoman generator for creating MEAN stack applications, using MongoDB, Express, AngularJS, and Node",
   "keywords": [
     "yeoman-generator",
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/sincraianul/generator-angular-material-fullstack",
   "bugs": "https://github.com/sincraianul/generator-angular-material-fullstack/issues",
   "author": "Andrei Sîncrăian",
+  "contributors": [],
   "repository": {
     "type": "git",
     "url": "git://github.com/sincraianul/generator-angular-material-fullstack.git"
@@ -29,39 +30,35 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "yeoman-generator": "~0.17.0",
-    "chalk": "~0.4.0",
-    "wiredep": "~0.4.2",
-    "generator-ng-component": "~0.0.4"
+    "chalk": "^0.4.0",
+    "generator-ng-component": "^0.1.1",
+    "wiredep": "^3.0.0",
+    "yeoman-generator": "^0.22.5"
   },
   "peerDependencies": {
     "yo": ">=1.2.0"
   },
   "devDependencies": {
-    "chai": "^1.9.1",
-    "fs-extra": "^0.9.1",
-    "grunt": "~0.4.1",
-    "grunt-build-control": "DaftMonk/grunt-build-control",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-conventional-changelog": "~1.0.0",
-    "grunt-mocha-test": "^0.11.0",
-    "grunt-release": "~0.6.0",
-    "load-grunt-tasks": "~0.2.0",
-    "marked": "~0.2.8",
-    "mocha": "~1.21.0",
-    "q": "^1.0.1",
-    "semver": "~2.2.1",
-    "shelljs": "^0.3.0",
-    "underscore.string": "^2.3.3"
+    "chai": "^3.5.0",
+    "fs-extra": "^0.26.5",
+    "grunt": "^0.4.5",
+    "grunt-build-control": "^0.6.2",
+    "grunt-contrib-clean": "^0.7.0",
+    "grunt-contrib-jshint": "^0.12.0",
+    "grunt-conventional-changelog": "^5.0.0",
+    "grunt-mocha-test": "^0.12.7",
+    "grunt-release": "^0.13.0",
+    "load-grunt-tasks": "^3.4.0",
+    "marked": "^0.3.5",
+    "mocha": "^2.4.5",
+    "q": "^1.4.1",
+    "semver": "^5.1.0",
+    "shelljs": "^0.5.3",
+    "underscore.string": "^3.2.3"
   },
   "engines": {
     "node": ">=0.10.0",
     "npm": ">=1.2.10"
   },
-  "licenses": [
-    {
-      "type": "BSD"
-    }
-  ]
+  "license": "BSD-2-Clause"
 }

--- a/provider/index.js
+++ b/provider/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var yeoman = require('yeoman-generator');
 
-var Generator = yeoman.generators.Base.extend({
+var Generator = yeoman.Base.extend({
   compose: function() {
     this.composeWith('ng-component:provider', {arguments: this.arguments}, { local: require.resolve('generator-ng-component/provider') });
   }

--- a/route/index.js
+++ b/route/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var yeoman = require('yeoman-generator');
 
-var Generator = yeoman.generators.Base.extend({
+var Generator = yeoman.Base.extend({
   compose: function() {
     this.composeWith('ng-component:route', {arguments: this.arguments}, { local: require.resolve('generator-ng-component/route') });
   }

--- a/service/index.js
+++ b/service/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var yeoman = require('yeoman-generator');
 
-var Generator = yeoman.generators.Base.extend({
+var Generator = yeoman.Base.extend({
   compose: function() {
     this.composeWith('ng-component:service', {arguments: this.arguments}, { local: require.resolve('generator-ng-component/service') });
   }

--- a/test/fixtures/bower.json
+++ b/test/fixtures/bower.json
@@ -9,10 +9,9 @@
     "angular-cookies": ">=1.2.*",
     "angular-messages": ">=1.2.*",
     "angular-sanitize": ">=1.2.*",
-    "angular-animate": ">=1.2.*",
     "angular-route": ">=1.2.*",
     "angular-material": "latest",
-    "lodash": "~2.4.1",
+    "lodash": "~4.1.1",
     "angular-socket-io": "~0.6.0",
     "angular-ui-router": "~0.2.15"
   },

--- a/test/test-file-creation.js
+++ b/test/test-file-creation.js
@@ -1,7 +1,7 @@
 /*global describe, beforeEach, it */
 'use strict';
 var path = require('path');
-var helpers = require('yeoman-generator').test;
+var helpers = require('yeoman-test');
 var chai = require('chai');
 var expect = chai.expect;
 var fs = require('fs-extra');


### PR DESCRIPTION
There's still a lot that needs to be done to get this updated but this is the start.

Running `grunt test` I get a LOT of errors, I can't seem to find `require('yeoman-generator').generators.Base` anywhere in the code even though mocha gives an error about it. The other main warning that needs to be fixed is the one about lodash.

```
➜  generator-angular-material-fullstack git:(master) ✗ npm test

> generator-angular-material-fullstack@0.1.3 test /Users/xo/code/generator-angular-material-fullstack
> grunt test

Running "updateFixtures" task

Running "installFixtures" task
>> installing npm dependencies for generated app
>> installing bower dependencies for generated app

Running "mochaTest:test" (mochaTest) task


  angular-material-fullstack generator
    running app
      with default options
(!) require('yeoman-generator').generators.Base is deprecated. Use require('yeoman-generator').Base directly
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        1) should run client tests successfully
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        2) should pass jshint
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        3) should run server tests successfully
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        4) should run server tests successfully with generated endpoint
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        5) should use existing config if available
      with Babel ES6 preprocessor
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        6) should run client tests successfully
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        7) should pass jshint
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        8) should run server tests successfully
      with other preprocessors and oauth
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        9) should run client tests successfully
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        10) should pass jshint
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        11) should run server tests successfully
      with other preprocessors and no server options
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        12) should run client tests successfully
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        13) should pass jshint
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        14) should run server tests successfully
      with no preprocessors and no server options
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        15) should run client tests successfully
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        16) should pass jshint
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        17) should run server tests successfully
(!) #_ is deprecated. Require your own version of Lodash or underscore.string
        18) should generate expected files


  0 passing (2s)
  18 failing

  1) angular-material-fullstack generator running app with default options should run client tests successfully:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  2) angular-material-fullstack generator running app with default options should pass jshint:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  3) angular-material-fullstack generator running app with default options should run server tests successfully:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  4) angular-material-fullstack generator running app with default options should run server tests successfully with generated endpoint:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  5) angular-material-fullstack generator running app with default options should use existing config if available:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  6) angular-material-fullstack generator running app with Babel ES6 preprocessor should run client tests successfully:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  7) angular-material-fullstack generator running app with Babel ES6 preprocessor should pass jshint:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  8) angular-material-fullstack generator running app with Babel ES6 preprocessor should run server tests successfully:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  9) angular-material-fullstack generator running app with other preprocessors and oauth should run client tests successfully:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  10) angular-material-fullstack generator running app with other preprocessors and oauth should pass jshint:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  11) angular-material-fullstack generator running app with other preprocessors and oauth should run server tests successfully:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  12) angular-material-fullstack generator running app with other preprocessors and no server options should run client tests successfully:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  13) angular-material-fullstack generator running app with other preprocessors and no server options should pass jshint:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  14) angular-material-fullstack generator running app with other preprocessors and no server options should run server tests successfully:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  15) angular-material-fullstack generator running app with no preprocessors and no server options should run client tests successfully:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  16) angular-material-fullstack generator running app with no preprocessors and no server options should pass jshint:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  17) angular-material-fullstack generator running app with no preprocessors and no server options should run server tests successfully:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8

  18) angular-material-fullstack generator running app with no preprocessors and no server options should generate expected files:
     Uncaught TypeError: Cannot read property 'camelize' of undefined
      at yeoman.generators.Base.extend.init (app/index.js:27:26)
      at Object.<anonymous> (node_modules/yeoman-generator/lib/base.js:436:25)
      at node_modules/run-async/index.js:24:25
      at node_modules/yeoman-generator/lib/base.js:448:8



Warning: Task "mochaTest:test" failed. Use --force to continue.

Aborted due to warnings.
npm ERR! Test failed.  See above for more details.
```
